### PR TITLE
add workaround for use-after-free in ~BlockingConnectionAdapter()

### DIFF
--- a/transport.cpp
+++ b/transport.cpp
@@ -297,8 +297,17 @@ BlockingConnectionAdapter::BlockingConnectionAdapter(std::unique_ptr<BlockingCon
     : underlying_(std::move(connection)) {}
 
 BlockingConnectionAdapter::~BlockingConnectionAdapter() {
-    LOG(INFO) << "BlockingConnectionAdapter(" << Serial() << "): destructing";
-    Stop();
+    bool stopped = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stopped = stopped_;
+    }
+    if (stopped) {
+        LOG(INFO) << "~BlockingConnectionAdapter: already stopped";
+    } else {
+        LOG(INFO) << "BlockingConnectionAdapter(" << Serial() << "): destructing";
+        Stop();
+    }
 }
 
 void BlockingConnectionAdapter::Start() {


### PR DESCRIPTION
Serial() in ~BlockingConnectionAdapter() and Stop() calls transport_->serial_name(). transport_ is already destroyed in some cases by that point.

Depends on:
https://github.com/GrapheneOS/platform_manifest/pull/62
https://github.com/GrapheneOS/script/pull/82

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/3641