### PR TITLE
adbconnection_listen: Remove connection fd from epoll before invoking callback

### DIFF
--- a/libs/adbconnection/adbconnection_server.cpp
+++ b/libs/adbconnection/adbconnection_server.cpp
@@ -138,14 +138,15 @@ void adbconnection_listen(void (*callback)(int fd, ProcessInfo process)) {
         }
 
         auto process_info = readProcessInfoFromSocket(it->get());
+
+        if (epoll_ctl(epfd.get(), EPOLL_CTL_DEL, event.data.fd, nullptr) != 0) {
+          PLOG(FATAL) << "failed to delete fd " << event.data.fd << " from JDWP epoll fd";
+        }
+
         if (process_info) {
           callback(it->release(), *process_info);
         } else {
           LOG(ERROR) << "Unable to read ProcessInfo from app startup";
-        }
-
-        if (epoll_ctl(epfd.get(), EPOLL_CTL_DEL, event.data.fd, nullptr) != 0) {
-          PLOG(FATAL) << "failed to delete fd " << event.data.fd << " from JDWP epoll fd";
         }
 
         pending_connections.erase(it);

--- a/libs/adbconnection/tests.cc
+++ b/libs/adbconnection/tests.cc
@@ -46,12 +46,14 @@ void waitForUpdateReceived() {
   cv.wait(lock);
 }
 
+std::atomic_bool should_run = true;
+
 void server_callback(int fd, ProcessInfo process) {
   info = process;
   onUpdateReceived();
   // After the first processinfo update is received, jdwp_service in adbd takes over reading
   // from the fd leveraging fdevent system. We emulate it by reading on a regular basis.
-  while (true) {
+  while (should_run) {
     auto optional = readProcessInfoFromSocket(fd);
     if (optional) {
       info = *optional;
@@ -59,6 +61,9 @@ void server_callback(int fd, ProcessInfo process) {
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
+
+  onUpdateReceived();
+  close(fd);
 }
 
 // This test mimics an app starting up and sending data as zygote is specializing
@@ -110,4 +115,9 @@ TEST(LibAdbConnectionTest, TestComm) {
   EXPECT_EQ(info.process_name, "my_process_name");
   EXPECT_EQ(info.user_id, 888);
   EXPECT_TRUE(info.waiting_for_debugger);
+
+  should_run = false;
+  waitForUpdateReceived();
+  // Wait for server to finish processing epoll events.
+  sleep(1);
 }


### PR DESCRIPTION
In `init_jdwp()`, the callback invokes a nested `fdevent_run_on_looper()` callback, which takes ownership of the connection fd and moves it to a `JdwpProcess` instance, which does further communication on the socket. However, the fdevent callback runs on a different thread, making this inherently racy. It's possible for the `JdwpProcess` instance to be destroyed and the fd closed prior to the fd getting unregistered from epoll in `adbconnection_listen()`. Trying to remove a closed fd from epoll results in the syscall failing with `-EBADF`.

This commit fixes the issue by having `adbconnection_listen()` unregister the fd prior to invoking the callback. We unconditionally unregister the fd anyway and the callback isn't given access to epoll. The existing adbconnection test is also updated to close the connection fd to simulate this scenario.

Fixes: GrapheneOS/os-issue-tracker#2724

---

Reproducing the original bug without the fix (but with the updated test):

```
❯ out/host/linux-x86/nativetest/libadbconnection_test/libadbconnection_test
Running main() from external/googletest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from LibAdbConnectionTest
[ RUN      ] LibAdbConnectionTest.TestComm
03-08 19:38:39.657 3101135 3101137 E libadbconnection_test: adbconnection_server.cpp:47 adbconnection_server: Unable to MSG_PEEK ProcessInfo recv: Resource temporarily unavailable
03-08 19:38:39.678 3101135 3101137 F libadbconnection_test: adbconnection_server.cpp:148 failed to delete fd 6 from JDWP epoll fd: Bad file descriptor
zsh: IOT instruction (core dumped)  out/host/linux-x86/nativetest/libadbconnection_test/libadbconnection_test
```

With the fix:

```
❯ out/host/linux-x86/nativetest/libadbconnection_test/libadbconnection_test
Running main() from external/googletest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from LibAdbConnectionTest
[ RUN      ] LibAdbConnectionTest.TestComm
03-08 19:39:32.436 3106148 3106149 E libadbconnection_test: adbconnection_server.cpp:47 adbconnection_server: Unable to MSG_PEEK ProcessInfo recv: Resource temporarily unavailable
[       OK ] LibAdbConnectionTest.TestComm (2020 ms)
[----------] 1 test from LibAdbConnectionTest (2020 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2020 ms total)
[  PASSED  ] 1 test.
```