### PR TITLE
Fix UAF when logging inside Connection's with destroyed atransport

### DIFF
--- a/transport.cpp
+++ b/transport.cpp
@@ -298,17 +298,8 @@ BlockingConnectionAdapter::BlockingConnectionAdapter(std::unique_ptr<BlockingCon
     : underlying_(std::move(connection)) {}
 
 BlockingConnectionAdapter::~BlockingConnectionAdapter() {
-    bool stopped = false;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        stopped = stopped_;
-    }
-    if (stopped) {
-        LOG(INFO) << "~BlockingConnectionAdapter: already stopped";
-    } else {
-        LOG(INFO) << "BlockingConnectionAdapter(" << Serial() << "): destructing";
-        Stop();
-    }
+    LOG(INFO) << "BlockingConnectionAdapter(" << Serial() << "): destructing";
+    Stop();
 }
 
 bool BlockingConnectionAdapter::Start() {

--- a/transport.cpp
+++ b/transport.cpp
@@ -747,6 +747,7 @@ static void fdevent_unregister_transport(atransport* t) {
         pending_list.remove(t);
     }
 
+    t->connection()->SetTransport(nullptr);
     delete t;
 
     update_transports();


### PR DESCRIPTION
Hopefully closes https://github.com/GrapheneOS/os-issue-tracker/issues/3641 (see bug details at https://github.com/GrapheneOS/os-issue-tracker/issues/3641#issuecomment-2779579927)

Unfortunately, I had to drop the "connection name" from the logs, since there's no simple way of avoiding the user-after-free without introducing significant changes (additional synchronization and caching).

Anyway, I will report the bug on AOSP, and hopefully they will apply a proper fix which we can downstream later.

I haven't tested these changes, but they are trivial.